### PR TITLE
Port to flink 1.3.2

### DIFF
--- a/FlinkExperiments/FlinkExperiment.iml
+++ b/FlinkExperiments/FlinkExperiment.iml
@@ -6,28 +6,28 @@
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
-      <excludeFolder url="file://$MODULE_DIR$/data" />
-      <excludeFolder url="file://$MODULE_DIR$/scripts" />
-      <excludeFolder url="file://$MODULE_DIR$/sql" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Maven: org.apache.flink:flink-java:1.1.2" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.flink:flink-core:1.1.2" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.flink:flink-annotations:1.1.2" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.flink:flink-metrics-core:1.1.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.flink:flink-java:1.3.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.flink:flink-core:1.3.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.flink:flink-annotations:1.3.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.flink:flink-metrics-core:1.3.2" level="project" />
     <orderEntry type="library" name="Maven: com.esotericsoftware.kryo:kryo:2.24.0" level="project" />
     <orderEntry type="library" name="Maven: com.esotericsoftware.minlog:minlog:1.2" level="project" />
     <orderEntry type="library" name="Maven: org.objenesis:objenesis:2.1" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.avro:avro:1.7.6" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.flink:flink-shaded-hadoop2:1.1.2" level="project" />
+    <orderEntry type="library" name="Maven: commons-collections:commons-collections:3.2.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.commons:commons-compress:1.4.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.avro:avro:1.7.7" level="project" />
+    <orderEntry type="library" name="Maven: com.thoughtworks.paranamer:paranamer:2.3" level="project" />
+    <orderEntry type="library" name="Maven: org.xerial.snappy:snappy-java:1.0.5" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.flink:flink-shaded-hadoop2:1.3.2" level="project" />
+    <orderEntry type="library" name="Maven: org.tukaani:xz:1.0" level="project" />
     <orderEntry type="library" name="Maven: xmlenc:xmlenc:0.52" level="project" />
     <orderEntry type="library" name="Maven: commons-codec:commons-codec:1.4" level="project" />
     <orderEntry type="library" name="Maven: commons-io:commons-io:2.4" level="project" />
     <orderEntry type="library" name="Maven: commons-net:commons-net:3.1" level="project" />
-    <orderEntry type="library" name="Maven: commons-collections:commons-collections:3.2.1" level="project" />
     <orderEntry type="library" name="Maven: javax.servlet:servlet-api:2.5" level="project" />
     <orderEntry type="library" name="Maven: org.mortbay.jetty:jetty-util:6.1.26" level="project" />
     <orderEntry type="library" name="Maven: com.sun.jersey:jersey-core:1.9" level="project" />
@@ -38,50 +38,39 @@
     <orderEntry type="library" name="Maven: commons-digester:commons-digester:1.8.1" level="project" />
     <orderEntry type="library" name="Maven: org.codehaus.jackson:jackson-core-asl:1.8.8" level="project" />
     <orderEntry type="library" name="Maven: org.codehaus.jackson:jackson-mapper-asl:1.8.8" level="project" />
-    <orderEntry type="library" name="Maven: com.thoughtworks.paranamer:paranamer:2.3" level="project" />
-    <orderEntry type="library" name="Maven: org.xerial.snappy:snappy-java:1.0.5" level="project" />
     <orderEntry type="library" name="Maven: com.jcraft:jsch:0.1.42" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.zookeeper:zookeeper:3.4.6" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.commons:commons-compress:1.4.1" level="project" />
-    <orderEntry type="library" name="Maven: org.tukaani:xz:1.0" level="project" />
     <orderEntry type="library" name="Maven: commons-beanutils:commons-beanutils-bean-collections:1.8.3" level="project" />
     <orderEntry type="library" name="Maven: commons-daemon:commons-daemon:1.0.13" level="project" />
     <orderEntry type="library" name="Maven: javax.xml.bind:jaxb-api:2.2.2" level="project" />
     <orderEntry type="library" name="Maven: javax.xml.stream:stax-api:1.0-2" level="project" />
     <orderEntry type="library" name="Maven: javax.activation:activation:1.1" level="project" />
-    <orderEntry type="library" name="Maven: com.google.inject:guice:3.0" level="project" />
-    <orderEntry type="library" name="Maven: javax.inject:javax.inject:1" level="project" />
-    <orderEntry type="library" name="Maven: aopalliance:aopalliance:1.0" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.commons:commons-math3:3.5" level="project" />
-    <orderEntry type="library" name="Maven: com.google.code.findbugs:jsr305:1.3.9" level="project" />
     <orderEntry type="library" name="Maven: org.apache.commons:commons-lang3:3.3.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.commons:commons-math3:3.5" level="project" />
     <orderEntry type="library" name="Maven: org.slf4j:slf4j-api:1.7.7" level="project" />
-    <orderEntry type="library" name="Maven: org.slf4j:slf4j-log4j12:1.7.7" level="project" />
-    <orderEntry type="library" name="Maven: log4j:log4j:1.2.17" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.flink:force-shading:1.1.2" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.flink:flink-streaming-java_2.10:1.1.2" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.flink:flink-runtime_2.10:1.1.2" level="project" />
+    <orderEntry type="library" name="Maven: com.google.code.findbugs:jsr305:1.3.9" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.flink:force-shading:1.3.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.flink:flink-streaming-java_2.10:1.3.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.flink:flink-runtime_2.10:1.3.2" level="project" />
     <orderEntry type="library" name="Maven: io.netty:netty-all:4.0.27.Final" level="project" />
     <orderEntry type="library" name="Maven: org.javassist:javassist:3.18.2-GA" level="project" />
     <orderEntry type="library" name="Maven: org.scala-lang:scala-library:2.10.4" level="project" />
-    <orderEntry type="library" name="Maven: com.typesafe.akka:akka-actor_2.10:2.3.7" level="project" />
+    <orderEntry type="library" name="Maven: com.data-artisans:flakka-actor_2.10:2.3-custom" level="project" />
     <orderEntry type="library" name="Maven: com.typesafe:config:1.2.1" level="project" />
-    <orderEntry type="library" name="Maven: com.typesafe.akka:akka-remote_2.10:2.3.7" level="project" />
+    <orderEntry type="library" name="Maven: com.data-artisans:flakka-remote_2.10:2.3-custom" level="project" />
     <orderEntry type="library" name="Maven: com.google.protobuf:protobuf-java:2.5.0" level="project" />
     <orderEntry type="library" name="Maven: org.uncommons.maths:uncommons-maths:1.2.2a" level="project" />
-    <orderEntry type="library" name="Maven: com.typesafe.akka:akka-slf4j_2.10:2.3.7" level="project" />
+    <orderEntry type="library" name="Maven: com.data-artisans:flakka-slf4j_2.10:2.3-custom" level="project" />
     <orderEntry type="library" name="Maven: org.clapper:grizzled-slf4j_2.10:1.0.2" level="project" />
-    <orderEntry type="library" name="Maven: com.github.scopt:scopt_2.10:3.2.0" level="project" />
-    <orderEntry type="library" name="Maven: io.dropwizard.metrics:metrics-core:3.1.0" level="project" />
-    <orderEntry type="library" name="Maven: io.dropwizard.metrics:metrics-jvm:3.1.0" level="project" />
-    <orderEntry type="library" name="Maven: io.dropwizard.metrics:metrics-json:3.1.0" level="project" />
+    <orderEntry type="library" name="Maven: com.github.scopt:scopt_2.10:3.5.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.zookeeper:zookeeper:3.4.6" level="project" />
+    <orderEntry type="library" name="Maven: jline:jline:0.9.94" level="project" />
     <orderEntry type="library" name="Maven: com.twitter:chill_2.10:0.7.4" level="project" />
     <orderEntry type="library" name="Maven: com.twitter:chill-java:0.7.4" level="project" />
     <orderEntry type="library" name="Maven: org.apache.sling:org.apache.sling.commons.json:2.0.6" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.flink:flink-clients_2.10:1.1.2" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.flink:flink-optimizer_2.10:1.1.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.flink:flink-clients_2.10:1.3.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.flink:flink-optimizer_2.10:1.3.2" level="project" />
     <orderEntry type="library" name="Maven: commons-cli:commons-cli:1.3.1" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.flink:flink-cep_2.10:1.1.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.flink:flink-cep_2.10:1.3.2" level="project" />
     <orderEntry type="library" name="Maven: de.bytefish:jtinycsvparser:1.2" level="project" />
     <orderEntry type="library" name="Maven: org.elasticsearch:elasticsearch:2.3.2" level="project" />
     <orderEntry type="library" name="Maven: org.apache.lucene:lucene-core:5.5.0" level="project" />

--- a/FlinkExperiments/pom.xml
+++ b/FlinkExperiments/pom.xml
@@ -21,15 +21,7 @@
         </plugins>
     </build>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <flink.version>1.3.2</flink.version>
-
-        <pgbulkinsert.version>1.1</pgbulkinsert.version>
-        <jtinycsvparser.version>1.2</jtinycsvparser.version>
-        <elasticutils.version>0.3</elasticutils.version>
-
-    </properties>
+link
 
     <dependencies>
 

--- a/FlinkExperiments/pom.xml
+++ b/FlinkExperiments/pom.xml
@@ -23,7 +23,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <flink.version>1.1.2</flink.version>
+        <flink.version>1.3.2</flink.version>
 
         <pgbulkinsert.version>1.1</pgbulkinsert.version>
         <jtinycsvparser.version>1.2</jtinycsvparser.version>

--- a/FlinkExperiments/src/main/java/app/WeatherDataStreamingExample.java
+++ b/FlinkExperiments/src/main/java/app/WeatherDataStreamingExample.java
@@ -8,6 +8,7 @@ import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.KeyedStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -25,14 +26,16 @@ public class WeatherDataStreamingExample {
 
     public static void main(String[] args) throws Exception {
 
+        ParameterTool argParameters = ParameterTool.fromArgs(args);
+
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         // Use the Measurement Timestamp of the Event:
         env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 
         // Path to read the CSV data from:
-        final String csvStationDataFilePath = "C:\\Users\\philipp\\Downloads\\csv\\201503station.txt";
-        final String csvLocalWeatherDataFilePath = "C:\\Users\\philipp\\Downloads\\csv\\201503hourly_sorted.txt";
+        final String csvStationDataFilePath = argParameters.getRequired("stationdata"); //"C:\\Users\\philipp\\Downloads\\csv\\201503station.txt";
+        final String csvLocalWeatherDataFilePath = argParameters.getRequired("weatherdata");  //"C:\\Users\\philipp\\Downloads\\csv\\201503hourly_sorted.txt";
 
         // Add the CSV Data Source and assign the Measurement Timestamp:
         DataStream<model.LocalWeatherData> localWeatherDataDataStream = env
@@ -41,7 +44,6 @@ public class WeatherDataStreamingExample {
                     @Override
                     public long extractAscendingTimestamp(LocalWeatherData localWeatherData) {
                         Date measurementTime = DateUtilities.from(localWeatherData.getDate(), localWeatherData.getTime(), ZoneOffset.ofHours(0));
-
                         return measurementTime.getTime();
                     }
                 });

--- a/FlinkExperiments/src/main/java/app/WeatherDataStreamingExample.java
+++ b/FlinkExperiments/src/main/java/app/WeatherDataStreamingExample.java
@@ -94,7 +94,7 @@ public class WeatherDataStreamingExample {
         //elasticDailyMaxTemperature.addSink(new LocalWeatherDataElasticSearchSink("127.0.0.1", 9300, 100));
 
         // Add a new Postgres Sink:
-        pgsqlDailyMaxTemperature.addSink(new LocalWeatherDataPostgresSink(URI.create("postgres://philipp:test_pwd@127.0.0.1:5432/sampledb"), 1000));
+        // pgsqlDailyMaxTemperature.addSink(new LocalWeatherDataPostgresSink(URI.create("postgres://philipp:test_pwd@127.0.0.1:5432/sampledb"), 1000));
 
         // Finally execute the Stream:
         env.execute("Max Temperature By Day example");

--- a/FlinkExperiments/src/main/java/app/cep/WeatherDataComplexEventProcessingExample.java
+++ b/FlinkExperiments/src/main/java/app/cep/WeatherDataComplexEventProcessingExample.java
@@ -26,6 +26,7 @@ import utils.DateUtilities;
 import java.time.ZoneOffset;
 import java.util.Date;
 import java.util.Map;
+import java.util.List;
 
 public class WeatherDataComplexEventProcessingExample {
 
@@ -100,7 +101,7 @@ public class WeatherDataComplexEventProcessingExample {
 
         DataStream<TWarningType> warnings = tempPatternStream.select(new PatternSelectFunction<LocalWeatherData, TWarningType>() {
             @Override
-            public TWarningType select(Map<String, LocalWeatherData> map) throws Exception {
+            public TWarningType select(Map<String, List<LocalWeatherData>> map) throws Exception {
                 return warningPattern.create(map);
             }
         }, new GenericTypeInfo<TWarningType>(warningPattern.getWarningTargetType()));

--- a/FlinkExperiments/src/main/java/app/cep/WeatherDataComplexEventProcessingExample.java
+++ b/FlinkExperiments/src/main/java/app/cep/WeatherDataComplexEventProcessingExample.java
@@ -38,8 +38,8 @@ public class WeatherDataComplexEventProcessingExample {
         env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 
         // Path to read the CSV data from:
-        final String csvStationDataFilePath = "C:\\Users\\philipp\\Downloads\\csv\\201503station.txt";
-        final String csvLocalWeatherDataFilePath = "C:\\Users\\philipp\\Downloads\\csv\\201503hourly_sorted.txt";
+        final String csvStationDataFilePath = "/Users/sklard/Downloads/QCLCD201708/201708station.txt";
+        final String csvLocalWeatherDataFilePath = "/Users/sklard/Downloads/QCLCD201708/201708hourly_sorted.txt";
 
 
         // Add the CSV Data Source and assign the Measurement Timestamp:

--- a/FlinkExperiments/src/main/java/app/cep/WeatherDataComplexEventProcessingExample.java
+++ b/FlinkExperiments/src/main/java/app/cep/WeatherDataComplexEventProcessingExample.java
@@ -11,6 +11,7 @@ import model.LocalWeatherData;
 import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.typeutils.GenericTypeInfo;
+import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.cep.CEP;
 import org.apache.flink.cep.PatternSelectFunction;
 import org.apache.flink.cep.PatternStream;
@@ -32,14 +33,16 @@ public class WeatherDataComplexEventProcessingExample {
 
     public static void main(String[] args) throws Exception {
 
+        ParameterTool argParameters = ParameterTool.fromArgs(args);
+
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         // Use the Measurement Timestamp of the Event:
         env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 
         // Path to read the CSV data from:
-        final String csvStationDataFilePath = "/Users/sklard/Downloads/QCLCD201708/201708station.txt";
-        final String csvLocalWeatherDataFilePath = "/Users/sklard/Downloads/QCLCD201708/201708hourly_sorted.txt";
+        final String csvStationDataFilePath = argParameters.getRequired("stationdata");
+        final String csvLocalWeatherDataFilePath = argParameters.getRequired("weatherdata");
 
 
         // Add the CSV Data Source and assign the Measurement Timestamp:

--- a/FlinkExperiments/src/main/java/app/cep/WeatherDataComplexEventProcessingExample.java
+++ b/FlinkExperiments/src/main/java/app/cep/WeatherDataComplexEventProcessingExample.java
@@ -29,6 +29,9 @@ import java.util.Date;
 import java.util.Map;
 import java.util.List;
 
+/*
+IMPORTANT:  This example activates only the SevereHeatWarning.
+ */
 public class WeatherDataComplexEventProcessingExample {
 
     public static void main(String[] args) throws Exception {

--- a/FlinkExperiments/src/main/java/app/cep/model/IWarningPattern.java
+++ b/FlinkExperiments/src/main/java/app/cep/model/IWarningPattern.java
@@ -7,6 +7,7 @@ import org.apache.flink.cep.pattern.Pattern;
 
 import java.io.Serializable;
 import java.util.Map;
+import java.util.List;
 
 /**
  * A Warning Pattern describes the pattern of a Warning, which is triggered by an Event.
@@ -22,7 +23,7 @@ public interface IWarningPattern<TEventType, TWarningType extends IWarning> exte
      * @param pattern Pattern, which has been matched by Apache Flink.
      * @return The warning created from the given match result.
      */
-    TWarningType create(Map<String, TEventType> pattern);
+    TWarningType create(Map<String, List<TEventType>> pattern);
 
     /**
      * Implementes the Apache Flink CEP Event Pattern which triggers a warning.

--- a/FlinkExperiments/src/main/java/app/cep/model/patterns/temperature/SevereHeatWarningPattern.java
+++ b/FlinkExperiments/src/main/java/app/cep/model/patterns/temperature/SevereHeatWarningPattern.java
@@ -18,11 +18,25 @@ public class SevereHeatWarningPattern implements IWarningPattern<LocalWeatherDat
     public SevereHeatWarningPattern() {}
 
     @Override
-    public SevereHeatWarning create(Map<String, List<LocalWeatherData>> pattern) {
-        LocalWeatherData first = pattern.get("First Event").get(0);
-        LocalWeatherData second = pattern.get("Second Event").get(0);
+    /*
+    To enable assert checks at runtime, use --ea
 
-        return new SevereHeatWarning(first, second);
+    TO: Philipp Wagner
+    FROM: DFSklar
+    Under normal conditions, each of the patterns comes in with only one LocalWeatherData record.
+    I have never encountered a case, when testing with the real-world weather-service data,
+    in which more than one is present, thus the asserts below.
+    However, I am looking for suggestions from you re: what should be done if multiple instances
+    of LocalWeatherData are present for a single "event".
+    I have added the asserts only to this particular WarningPattern (severe heat) but
+    obviously the decision we make here must be brought over to the other patterns in this app.
+    */
+    public SevereHeatWarning create(Map<String, List<LocalWeatherData>> pattern) {
+        List<LocalWeatherData> first = pattern.get("First Event");
+        assert(first.size() == 1);   // See comment above
+        List<LocalWeatherData> second = pattern.get("Second Event");
+        assert(second.size() == 1);   // See comment above
+        return new SevereHeatWarning(first.get(0), second.get(0));
     }
 
     @Override

--- a/FlinkExperiments/src/main/java/app/cep/model/patterns/wind/ExtremeWindWarningPattern.java
+++ b/FlinkExperiments/src/main/java/app/cep/model/patterns/wind/ExtremeWindWarningPattern.java
@@ -8,8 +8,10 @@ import app.cep.model.warnings.temperature.ExtremeColdWarning;
 import app.cep.model.warnings.wind.ExtremeWindWarning;
 import model.LocalWeatherData;
 import org.apache.flink.cep.pattern.Pattern;
+import org.apache.flink.cep.pattern.conditions.SimpleCondition;
 
 import java.util.Map;
+import java.util.List;
 
 public class ExtremeWindWarningPattern implements IWarningPattern<LocalWeatherData, ExtremeWindWarning> {
 
@@ -18,17 +20,24 @@ public class ExtremeWindWarningPattern implements IWarningPattern<LocalWeatherDa
     }
 
     @Override
-    public ExtremeWindWarning create(Map<String, LocalWeatherData> pattern) {
-        LocalWeatherData first = pattern.get("First Event");
+    public ExtremeWindWarning create(Map<String, List<LocalWeatherData>> pattern) {
+        LocalWeatherData first = pattern.get("First Event").get(0);
 
         return new ExtremeWindWarning(first);
     }
 
     @Override
     public Pattern<LocalWeatherData, ?> getEventPattern() {
+        SimpleCondition<LocalWeatherData> checkIsAnomaly =
+                new SimpleCondition<LocalWeatherData>() {
+                    @Override
+                    public boolean filter(LocalWeatherData value) throws Exception {
+                        return value.getWindSpeed() > 110;
+                    }
+                };
         return Pattern
                 .<LocalWeatherData>begin("First Event")
-                .where(evt -> evt.getWindSpeed() > 110);
+                .where(checkIsAnomaly);
     }
 
     @Override

--- a/FlinkExperiments/src/main/java/app/cep/model/patterns/wind/HighWindWarningPattern.java
+++ b/FlinkExperiments/src/main/java/app/cep/model/patterns/wind/HighWindWarningPattern.java
@@ -7,8 +7,10 @@ import app.cep.model.IWarningPattern;
 import app.cep.model.warnings.wind.HighWindWarning;
 import model.LocalWeatherData;
 import org.apache.flink.cep.pattern.Pattern;
+import org.apache.flink.cep.pattern.conditions.SimpleCondition;
 
 import java.util.Map;
+import java.util.List;
 
 public class HighWindWarningPattern implements IWarningPattern<LocalWeatherData, HighWindWarning> {
 
@@ -17,17 +19,24 @@ public class HighWindWarningPattern implements IWarningPattern<LocalWeatherData,
     }
 
     @Override
-    public HighWindWarning create(Map<String, LocalWeatherData> pattern) {
-        LocalWeatherData first = pattern.get("First Event");
+    public HighWindWarning create(Map<String, List<LocalWeatherData>> pattern) {
+        LocalWeatherData first = pattern.get("First Event").get(0);
 
         return new HighWindWarning(first);
     }
 
     @Override
     public Pattern<LocalWeatherData, ?> getEventPattern() {
+        SimpleCondition<LocalWeatherData> checkIsAnomaly =
+                new SimpleCondition<LocalWeatherData>() {
+                    @Override
+                    public boolean filter(LocalWeatherData value) throws Exception {
+                        return value.getWindSpeed() >= 39  && value.getWindSpeed() <= 110;
+                    }
+                };
         return Pattern
                 .<LocalWeatherData>begin("First Event")
-                .where(evt -> evt.getWindSpeed() >= 39 && evt.getWindSpeed() <= 110);
+                .where(checkIsAnomaly);
     }
 
     @Override

--- a/FlinkExperiments/src/main/java/csv/model/Station.java
+++ b/FlinkExperiments/src/main/java/csv/model/Station.java
@@ -39,7 +39,11 @@ public class Station {
     }
 
     public String getWban() {
-        return wban;
+        if (wban.equalsIgnoreCase("")) {
+            return "WMO:" + wmo;  // Recent weather-service data has some cases where WBAN is empty
+        } else {
+            return wban;
+        }
     }
 
     public void setWban(String wban) {

--- a/FlinkExperiments/src/main/java/csv/sorting/PrepareWeatherData.java
+++ b/FlinkExperiments/src/main/java/csv/sorting/PrepareWeatherData.java
@@ -28,9 +28,9 @@ public class PrepareWeatherData {
     public static void main(String[] args) throws Exception {
 
         // Path to read the CSV data from:
-        final Path csvStationDataFilePath = FileSystems.getDefault().getPath("C:\\Users\\philipp\\Downloads\\csv\\201503station.txt");
-        final Path csvLocalWeatherDataUnsortedFilePath = FileSystems.getDefault().getPath("C:\\Users\\philipp\\Downloads\\csv\\201503hourly.txt");
-        final Path csvLocalWeatherDataSortedFilePath = FileSystems.getDefault().getPath("C:\\Users\\philipp\\Downloads\\csv\\201503hourly_sorted.txt");
+        final Path csvStationDataFilePath = FileSystems.getDefault().getPath("/Users/sklard/Downloads/QCLCD201708/201708station.txt");
+        final Path csvLocalWeatherDataUnsortedFilePath = FileSystems.getDefault().getPath("/Users/sklard/Downloads/QCLCD201708/201708hourly.txt");
+        final Path csvLocalWeatherDataSortedFilePath = FileSystems.getDefault().getPath("/Users/sklard/Downloads/QCLCD201708/201708hourly_sorted.txt");
 
         // A map between the WBAN and Station for faster Lookups:
         final Map<String, Station> stationMap = getStationMap(csvStationDataFilePath);

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This project is a sample project for [Apache Flink]. The application parses the 
 March 2015, calculates the maximum daily temperature of the stream by using [Apache Flink] and writes the results back into an [Elasticsearch] 
 and [PostgreSQL] database.
 
+Requires flink 1.3.2.
+
 ## Dataset ##
 
 The data is the [Quality Controlled Local Climatological Data (QCLCD)]: 
@@ -27,6 +29,11 @@ I have written a small application, that sorts the original CSV data by the meas
 * [PrepareWeatherData.java](https://github.com/bytefish/FlinkExperiments/blob/master/FlinkExperiments/src/main/java/csv/sorting/PrepareWeatherData.java)
 
 The result is a sorted CSV file, which can be used to run the examples.
+
+Command line parameters are required to run the `WeatherDataComplexEventProcessingExample` example, which looks for only severe-heat temperature conditions::
+* `--stationdata <fullpath>`
+* `--weatherdata <fullpath>`
+
 
 ## Further Reading ##
 


### PR DESCRIPTION
- Port to 1.3.2
- Required command-line parameters for the `WeatherDataComplexEventProcessingExample` application allow for easier customization of location of input data.

Important: see comments in `app/cep/model/patterns/temperature/SevereHeatWarningPattern.java` regarding an important change in semantics that occurred with 1.3.2 and possible impact on the current pattern-handling algorithm.
